### PR TITLE
use async rimraf

### DIFF
--- a/index.js
+++ b/index.js
@@ -129,9 +129,8 @@ Funnel.prototype.handleReadTree = function(inputTreeRoot) {
 };
 
 Funnel.prototype.cleanup = function() {
-  // must be sync until https://github.com/broccolijs/broccoli/pull/197 lands
   if (fs.existsSync(this._tmpDir)) {
-    return rimraf.sync(this._tmpDir);
+    return rimraf(this._tmpDir);
   }
 };
 


### PR DESCRIPTION
Now that https://github.com/broccolijs/broccoli/pull/197 has landed we can use async rimraf which has better retry semantics on windows. Hoping this can random ember-cli cleanup failures: https://github.com/ember-cli/ember-cli/issues/3044