### PR TITLE
Don’t mutate any filter arrays passed in.

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,15 +63,16 @@ Funnel.prototype.setupDestPaths = function() {
 };
 
 Funnel.prototype._setupFilter = function(type) {
-  var filters = this[type];
-
-  if (!filters) {
+  if (!this[type]) {
     return;
   }
 
-  if (!Array.isArray(filters)) {
-    throw new Error('Invalid ' + type + ' option, it must be an array. You specified `' + typeof filters + '`.');
+  if (!Array.isArray(this[type])) {
+    throw new Error('Invalid ' + type + ' option, it must be an array. You specified `' + typeof this[type] + '`.');
   }
+
+  // Clone the filter array so we are not mutating an external variable
+  var filters = this[type] = this[type].slice(0);
 
   for (var i = 0, l = filters.length; i < l; i++) {
     filters[i] = this._processPattern(filters[i]);

--- a/tests/index.js
+++ b/tests/index.js
@@ -221,6 +221,12 @@ describe('broccoli-funnel', function(){
         'subdir1/subsubdir2/',
         'subdir1/subsubdir2/some.js'
       ]);
+
+      it('is not mutated', function() {
+        var include = [ '**/*.unknown' ];
+        testFiltering(include, null, null, []);
+        expect(include[0]).to.eql('**/*.unknown');
+      });
     });
 
     describe('exclude filtering', function() {
@@ -252,6 +258,12 @@ describe('broccoli-funnel', function(){
         'subdir2/',
         'subdir2/bar.css'
       ]);
+
+      it('is not mutated', function() {
+        var exclude = [ '**/*' ];
+        testFiltering(null, exclude, null, []);
+        expect(exclude[0]).to.eql('**/*');
+      });
     });
 
     it('combined filtering', function() {


### PR DESCRIPTION
They might be external variables used by other code. This tripped me up for a little while, because I was re-using a filter array variable in other code and it was unexpectedly not an array of strings anymore (it was mutated into an array of objects).