### PR TITLE
Ensure that cleanup works when output dir is a broken symlink.

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,9 +133,7 @@ Funnel.prototype.handleReadTree = function(inputTreeRoot) {
 };
 
 Funnel.prototype.cleanup = function() {
-  if (fs.existsSync(this._tmpDir)) {
-    return rimraf(this._tmpDir);
-  }
+  return rimraf(this._tmpDir);
 };
 
 Funnel.prototype.processFilters = function(inputPath) {


### PR DESCRIPTION
* `fs.existsSync(somePath)` returns false if `somePath` is a broken symlink (because it is using `fs.stat` and following symlinks).
* The prior cleanup code attempted to avoid unneeded cleanup when the output dir didn't already exist, but this checking actually
  hit the issue mentioned above when the input tree's output path has changed (causing the prior symlink to be pointing to an invalid
  location).
* Added a test for this issue, and a number of tests confirming that rebuilds work in general (it was previously untested).