### PR TITLE
Why no optional `new`?

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# master
+
+* Use [new `.rebuild` API](https://github.com/broccolijs/broccoli/blob/master/docs/new-rebuild-api.md)
+
+# 0.2.2
+
+No changelog beyond this point. Here be dragons.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # master
 
+* Make `new` operator optional
 * Use [new `.rebuild` API](https://github.com/broccolijs/broccoli/blob/master/docs/new-rebuild-api.md)
 
 # 0.2.2

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function makeDictionary() {
 }
 
 function Funnel(inputTree, options) {
-  if (!(this instanceof Funnel)) { console.error(new Error('You must use \'new Funnel\' to instantiate a broccoli-funnel item.')); }
+  if (!(this instanceof Funnel)) { return new Funnel(inputTree, options); }
 
   this.inputTree = inputTree;
 


### PR DESCRIPTION
I was just trying to update the [example in the Broccoli README](https://github.com/broccolijs/broccoli#using-plugins-in-a-brocfilejs) to use funnel instead of static-compiler, and I noticed that broccoli-funnel doesn't support `new`-less instantiation. Before I put `new Funnel` on the Broccoli README (which is a bit different from how most plugins are instantiated), I figured I'd just ask, is there a reason why you don't like the newless style?

I'm attaching a PR in case you want to allow it.

I goes well with a verbey invocation style as well, using `funnel` as in "to funnel":

```js
var funnel = require('funnel');
var newTree = funnel('foo', ...);
```